### PR TITLE
Updating some API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#
+- Removing GW methods: `getProcListResults` and `getProcListLiveResults`
+- Renaming GW methods: `getScrutinizerEntities` into `getEntityList`
+
 # 0.20.0
 - Update `getGatewayInfo` to `getInfo`
 - Update Ens public resolver

--- a/lib/net/gateway-dvote.dart
+++ b/lib/net/gateway-dvote.dart
@@ -28,7 +28,6 @@ class DVoteApiList {
     "getEnvelopeList",
     "getBlockHeight",
     "getBlockStatus",
-    "getResults",
     "submitRawTx"
   ];
   static const census = <String>[
@@ -43,13 +42,12 @@ class DVoteApiList {
     "dumpPlain",
     "importDump",
     "publish",
-    "importRemote"
+    "importRemote",
+    "getCensusList
   ];
   static const results = <String>[
-    "getProcListResults",
-    "getProcListLiveResults",
     "getResults",
-    "getScrutinizerEntities"
+    "getEntityList"
   ];
 }
 


### PR DESCRIPTION
- Removing GW methods: `getProcListResults` and `getProcListLiveResults`
- Renaming GW methods: `getScrutinizerEntities` into `getEntityList`
